### PR TITLE
Add migration and compare script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run tests
         run: python -m pytest -vv --cov hatch_jupyter_builder --cov-branch --cov-report term-missing:skip-covered --cov-fail-under 90
       - name: Run Migration Tests
-        run: python -m pytest -vv --migration-tests True
+        run: python -m pytest -vv -s --migration-tests True
 
   pre-commit:
     name: pre-commit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,8 @@ jobs:
         run: pip install -e ".[test]"
       - name: Run tests
         run: python -m pytest -vv --cov hatch_jupyter_builder --cov-branch --cov-report term-missing:skip-covered --cov-fail-under 90
+      - name: Run Migration Tests
+        run: python -m pytest -vv --migration-tests
 
   pre-commit:
     name: pre-commit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run tests
         run: python -m pytest -vv --cov hatch_jupyter_builder --cov-branch --cov-report term-missing:skip-covered --cov-fail-under 90
       - name: Run Migration Tests
-        run: python -m pytest -vv --migration-tests
+        run: python -m pytest -vv --migration-tests True
 
   pre-commit:
     name: pre-commit

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ To migrate, run the following:
 python -m hatch_jupyter_builder.migration .
 ```
 
+The migration script will do most of the migration automatically, but
+will prompt you for anything it cannot do itself.
+
 To compare dist files with a reference checkout, run the following:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ The optional `install-pre-commit-hook` boolean causes a `pre-commit` hook to be 
 This library provides a convenenice `npm_builder` function which can be
 used to build `npm` assets as part of the build.
 
+## Migration
+
+This library can be used to migrate from a `setuptools` based package to
+use `hatch_jupyter_builder`. It will attempt to migrate `jupyter-packaging`
+config as well, if present.
+
+To migrate, run the following:
+
+```bash
+python -m hatch_jupyter_builder.migration .
+```
+
+To compare dist files with a reference checkout, run the following:
+
+```bash
+python -m hatch_jupyter_builder.migration.compare <source_dir> <target_dir> sdist
+```
+
+Use `wheel` to compare wheel file contents.
+
 ## Local Development
 
 To test this package locally with another package, use the following:

--- a/hatch_jupyter_builder/migration/__main__.py
+++ b/hatch_jupyter_builder/migration/__main__.py
@@ -1,0 +1,33 @@
+"""Migrate a Jupyter project from setuptools/jupyter-packaging to hatch and
+hatch_jupyter_builder."""
+import argparse
+import os
+import subprocess
+import venv
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+parser = argparse.ArgumentParser()
+parser.add_argument(dest="target_dir", help="Target Directory")
+
+# Parse and print the results
+args = parser.parse_args()
+
+with TemporaryDirectory() as td:
+    venv.create(td, with_pip=True)
+    if os.name == "nt":
+        python = Path(td) / "Scripts/python.exe"
+    else:
+        python = Path(td) / "bin/python"
+
+    print("Installing in temporary virtual environment...")
+
+    # Create a virtual environment and use it to run the migration.
+    subprocess.run([python, "-m", "pip", "install", "-v", "-e", args.target_dir])
+    subprocess.run([python, "-m", "pip", "install", "jupyter_packaging"])
+    subprocess.run([python, "-m", "pip", "install", "tomli_w"])
+    subprocess.run([python, "-m", "pip", "install", "tomli"])
+    subprocess.run([python, "-m", "pip", "install", "hatch"])
+
+    migrator = Path(__file__).parent / "migrate_core.py"
+    subprocess.run([python, migrator], cwd=args.target_dir)

--- a/hatch_jupyter_builder/migration/__main__.py
+++ b/hatch_jupyter_builder/migration/__main__.py
@@ -23,11 +23,12 @@ with TemporaryDirectory() as td:
     print("Installing in temporary virtual environment...")
 
     # Create a virtual environment and use it to run the migration.
-    subprocess.run([python, "-m", "pip", "install", "-v", "-e", args.target_dir])
+    subprocess.run([python, "-m", "pip", "install", "build"])
     subprocess.run([python, "-m", "pip", "install", "jupyter_packaging"])
     subprocess.run([python, "-m", "pip", "install", "tomli_w"])
     subprocess.run([python, "-m", "pip", "install", "tomli"])
     subprocess.run([python, "-m", "pip", "install", "hatch"])
+    subprocess.run([python, "-m", "build", args.target_dir, "--sdist"])
 
-    migrator = Path(__file__).parent / "migrate_core.py"
+    migrator = Path(__file__).parent / "_migrate.py"
     subprocess.run([python, migrator], cwd=args.target_dir)

--- a/hatch_jupyter_builder/migration/_migrate.py
+++ b/hatch_jupyter_builder/migration/_migrate.py
@@ -1,0 +1,142 @@
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import tomli
+import tomli_w
+
+# Automatic migration from hatch.
+subprocess.run([sys.executable, "-m", "hatch", "new", "--init"])
+
+# Handle setup.cfg
+# Move flake8 config to separate file, preserving comments.
+# Add .flake8 file to git.
+# Remove file when done.
+setup_cfg = Path("setup.cfg")
+flake8 = ["[flake8]"]
+if setup_cfg.exists():
+    lines = setup_cfg.read_text("utf-8").splitlines()
+    matches = False
+    for line in lines:
+        if line.strip() == "[flake8]":
+            matches = True
+            continue
+
+        if not matches:
+            continue
+
+        if matches and line.startswith("["):
+            break
+
+        flake8.append(line)
+
+    Path(".flake8").write_text("\n".join(flake8) + "\n", "utf-8")
+
+    subprocess.run(["git", "add", ".flake"])
+    subprocess.run(["git", "rm", "setup.cfg"])
+
+
+# Handle pyproject.toml config.
+# Migrate and remove unused config.
+pyproject = Path("pyproject.toml")
+text = pyproject.read_text("utf-8")
+data = tomli.loads(text)
+
+tool_table = data.setdefault("tool", {})
+
+# Remove old check-manifest config.
+if "check-manifest" in tool_table:
+    del tool_table["check-manifest"]
+
+# Build up the hatch config.
+hatch_table = tool_table.setdefault("hatch", {})
+build_table = hatch_table.setdefault("build", {})
+targets_table = build_table.setdefault("targets", {})
+
+# Remove any auto-generated sdist config.
+if "sdist" in targets_table:
+    del targets_table["sdist"]
+
+# Exclude the .github folder by default.
+targets_table["sdist"] = dict(exclude=[".github"])
+
+hooks_table = build_table.setdefault("hooks", {})
+hooks_table["jupyter-builder"] = {}
+builder_table: dict = hooks_table["jupyter-builder"]
+builder_table["dependencies"] = ["hatch-jupyter-builder>=0.3.3"]
+
+# Migrate the jupyter-packaging static data.
+if "jupyter-packaging" in tool_table:
+    packaging_table = tool_table.get("jupyter-packaging", {})
+    del tool_table["jupyter-packaging"]
+
+    options_table = packaging_table.setdefault("options", {})
+    build_args_table = packaging_table.setdefault("build-args", {})
+    builder_table["build-function"] = "hatch_jupyter_builder.npm_builder"
+
+    for option in ["ensured-targets", "skip-if-exists"]:
+        if option in options_table:
+            builder_table[option] = options_table[option]
+
+    if build_args_table:
+        builder_table["build-kwargs"] = build_args_table.copy()
+
+# Add artifacts config for package data that would be ignored.
+project_name = data.get("project", {}).get("name", "")
+gitignore = Path(".gitignore")
+artifacts = []
+if gitignore.exists() and project_name and Path(project_name).exists():
+    text = gitignore.read_text("utf-8")
+    for line in text.splitlines():
+        if line.startswith(project_name):
+            artifacts.append(f"{line}")
+if artifacts:
+    build_table["artifacts"] = artifacts
+
+# Use code to get version in _version.py if avaiable.
+version_py_path = Path(project_name) / "_version.py"
+if version_py_path.exists():
+    hatch_table["version"] = dict(source="code", path=str(version_py_path))
+
+# Handle setup.py - jupyter_packaging and pre-commit config.
+# Remove the file when finished.
+setup_py = Path("setup.py")
+if setup_py.exists():
+    text = setup_py.read_text("utf-8")
+    if "pre-commit" in text:
+        builder_table["install-pre-commit"] = True
+
+    build_kwargs = builder_table.setdefault("build-kwargs", {})
+    editable_build_command = None
+    if "build_cmd" in text:
+        match = re.search('build_cmd="(.*?)"', text, re.MULTILINE)
+        assert match is not None
+        editable_build_command = match.groups()[0]
+
+    if "source_dir" in text or "build_dir" in text:
+        builder_table["editable-build-kwargs"] = {}
+        editable_build_kwargs: dict = builder_table["editable-build-kwargs"]
+        editable_build_kwargs["build_cmd"] = editable_build_command
+
+        for name in ["source_dir", "build_dir"]:
+            if name not in text:
+                continue
+            match = re.search(f'{name}="(.*?)"', text, re.MULTILINE)
+            if match is not None:
+                editable_build_kwargs[name] = match.groups()[0]
+            else:
+                editable_build_kwargs[name] = "!!! needs manual input !!!"
+
+    elif editable_build_command:
+        build_kwargs["editable_build_cmd"] = editable_build_command
+
+    subprocess.run(["git", "rm", "setup.py"])
+
+# Remove manifest file if it exists.
+if os.path.exists("MANIFEST.in"):
+    subprocess.run(["git", "rm", "MANIFEST.in"])
+
+# Write out the new config.
+pyproject.write_text(tomli_w.dumps(data), "utf-8")

--- a/hatch_jupyter_builder/migration/_migrate.py
+++ b/hatch_jupyter_builder/migration/_migrate.py
@@ -21,7 +21,7 @@ if setup_py.exists():
         .strip()
     )
 else:
-    warnings.append("Fill in [project][version] in pyproject.toml")
+    warnings.append("Fill in '[project][version]' in 'pyproject.toml'")
     current_version = "!!UNKONWN!!"
 
 
@@ -139,7 +139,7 @@ if setup_py.exists():
                 editable_build_kwargs[name] = match.groups()[0]
             else:
                 warnings.append(
-                    f"Fill in [tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs][{name}] in pyproject.toml, which was the {name} argument to npm_builder in setup.py"
+                    f"Fill in '[tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs][{name}]' in 'pyproject.toml', which was the '{name}' argument to 'npm_builder' in 'setup.py'"
                 )
                 editable_build_kwargs[name] = "!!! needs manual input !!!"
 
@@ -170,7 +170,9 @@ if setup_py.exists():
         tbump_table["file"].append(dict(src=str(version_py)))
         text = version_py.read_text(encoding="utf-8")
         if current_version not in text:
-            warnings.append(f'Add the current version string "{current_version}" to {version_py}')
+            warnings.append(
+                f'Add the static version string "{current_version}" to "{version_py}" instead of dynamic version handling'
+            )
 
     # Add entry for package.json if it exists and has the same version.
     package_json = Path("package.json")

--- a/hatch_jupyter_builder/migration/compare.py
+++ b/hatch_jupyter_builder/migration/compare.py
@@ -1,0 +1,73 @@
+"""Compare the dist file created by a migrated package to one created by the original."""
+import argparse
+import glob
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import zipfile
+
+parser = argparse.ArgumentParser()
+parser.add_argument(dest="source_dir", help="Source Directory")
+parser.add_argument(dest="target_dir", help="Target Directory")
+parser.add_argument(dest="dist_name", help="Dist name")
+
+args = parser.parse_args()
+
+subprocess.run([sys.executable, "-m", "pip", "install", "build"])
+
+
+def build_file(dirname):
+    orig_dir = os.getcwd()
+    os.chdir(dirname)
+    if os.path.exists("dist"):
+        shutil.rmtree("dist")
+    subprocess.run([sys.executable, "-m", "build", f"--{args.dist_name}"])
+    os.chdir(orig_dir)
+
+
+def get_tar_names(dirname):
+    dist_file = glob.glob(f"{dirname}/dist/*.tar.gz")[0]
+    tarf = tarfile.open(dist_file, "r:gz")
+    return set(tarf.getnames())
+
+
+def get_zip_names(dirname):
+    wheel_file = glob.glob(f"{dirname}/dist/*.whl")[0]
+    with zipfile.ZipFile(wheel_file, "r") as f:
+        return set(f.namelist())
+
+
+def filter_file(path, root):
+    if "egg-info" in path:
+        return True
+    full_path = os.path.join(path, root)
+    if os.path.isdir(full_path):
+        return True
+    if os.path.basename(path) in [path, "setup.py", "setup.cfg", "MANIFEST.in"]:
+        return True
+    return False
+
+
+build_file(args.source_dir)
+build_file(args.target_dir)
+
+if args.dist_name == "sdist":
+    source_names = get_tar_names(args.source_dir)
+    target_names = get_tar_names(args.target_dir)
+else:
+    source_names = get_zip_names(args.source_dir)
+    target_names = get_zip_names(args.target_dir)
+
+removed = source_names - target_names
+if removed:
+    print("\nRemoved_files:")
+    [print(f) for f in removed if not filter_file(f, args.source_dir)]
+
+added = target_names - source_names
+if added:
+    print("\nAdded files:")
+    [print(f) for f in added if not filter_file(f, args.target_dir)]
+
+print()

--- a/hatch_jupyter_builder/migration/compare.py
+++ b/hatch_jupyter_builder/migration/compare.py
@@ -61,13 +61,18 @@ else:
     target_names = get_zip_names(args.target_dir)
 
 removed = source_names - target_names
+removed = [r for r in removed if not filter_file(r, args.source_dir)]
 if removed:
     print("\nRemoved_files:")
-    [print(f) for f in removed if not filter_file(f, args.source_dir)]
+    [print(f) for f in removed]
 
 added = target_names - source_names
+added = [a for a in added if not filter_file(a, args.target_dir)]
 if added:
     print("\nAdded files:")
-    [print(f) for f in added if not filter_file(f, args.target_dir)]
+    [print(f) for f in added]
 
 print()
+
+if added or removed:
+    sys.exit(1)

--- a/hatch_jupyter_builder/utils.py
+++ b/hatch_jupyter_builder/utils.py
@@ -11,10 +11,9 @@ from typing import Any, Callable, Dict, List, Optional, Union
 if sys.platform == "win32":  # pragma: no cover
     from subprocess import list2cmdline
 else:
-    import pipes
 
     def list2cmdline(cmd_list):
-        return " ".join(map(pipes.quote, cmd_list))
+        return " ".join(map(shlex.quote, cmd_list))
 
 
 _logger = None
@@ -116,7 +115,7 @@ def npm_builder(
         log.info("Installing build dependencies with npm.  This may take a while...")
         run(npm_cmd + ["install"], cwd=str(abs_path))
         if build_cmd:
-            run(npm_cmd + ["run", build_cmd], cwd=str(abs_path))
+            run(npm_cmd + ["run", build_cmd], cwd=str(abs_path), check=True)
 
 
 def is_stale(target: Union[str, Path], source: Union[str, Path]) -> bool:

--- a/hatch_jupyter_builder/utils.py
+++ b/hatch_jupyter_builder/utils.py
@@ -113,7 +113,7 @@ def npm_builder(
 
     if should_build:
         log.info("Installing build dependencies with npm.  This may take a while...")
-        run(npm_cmd + ["install"], cwd=str(abs_path))
+        run(npm_cmd + ["install"], cwd=str(abs_path), check=True)
         if build_cmd:
             run(npm_cmd + ["run", build_cmd], cwd=str(abs_path), check=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ Issues = "https://github.com/jupyterlab/hatch-jupyter-builder/issues"
 Source = "https://github.com/jupyterlab/hatch-jupyter"
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-mock", "pre-commit", "hatchling", "pytest-cov"]
+test = ["pytest", "pytest-mock", "pre-commit", "hatchling", "pytest-cov", "tomli", "twine"]
 
 [project.entry-points.hatch]
 jupyter = "hatch_jupyter_builder.hooks"
@@ -47,6 +47,7 @@ addopts = "-raXs --durations 10 --color=yes --doctest-modules"
 testpaths = [
     "tests/"
 ]
+norecursedirs = "tests/data/*"
 filterwarnings = [
   "error"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ skip = ["check-links"]
 
 [tool.jupyter-releaser.options]
 post-version-spec = "dev"
+ignore-glob = ["tests/data/myextension/README.md"]
 
 [tool.tbump.version]
 current = "0.5.0.dev0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--migration-tests",
+        default=False,
+        type=bool,
+        help="only run tests with the 'migration_test' pytest mark.",
+    )
+
+
+def pytest_configure(config):
+    # register an additional marker
+    config.addinivalue_line("markers", "migration_test")
+
+
+def pytest_runtest_setup(item):
+    is_migration_test = any(mark for mark in item.iter_markers(name="migration_test"))
+
+    if item.config.getoption("--migration-tests") is True:
+        if not is_migration_test:
+            pytest.skip("Only running tests marked as 'migration_test'.")
+    else:
+        if is_migration_test:
+            pytest.skip(
+                "Skipping this test because it's marked 'migration_test'. Run integration tests using the `--migration-tests` flag."
+            )

--- a/tests/data/myextension/.eslintignore
+++ b/tests/data/myextension/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+coverage
+**/*.d.ts
+tests

--- a/tests/data/myextension/.eslintrc.js
+++ b/tests/data/myextension/.eslintrc.js
@@ -1,0 +1,39 @@
+module.exports = {
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended'
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'interface',
+        format: ['PascalCase'],
+        custom: {
+          regex: '^I[A-Z]',
+          match: true
+        }
+      }
+    ],
+    '@typescript-eslint/no-unused-vars': ['warn', { args: 'none' }],
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-namespace': 'off',
+    '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/quotes': [
+      'error',
+      'single',
+      { avoidEscape: true, allowTemplateLiterals: false }
+    ],
+    curly: ['error', 'all'],
+    eqeqeq: 'error',
+    'prefer-arrow-callback': 'error'
+  }
+};

--- a/tests/data/myextension/.eslintrc.js
+++ b/tests/data/myextension/.eslintrc.js
@@ -1,39 +1,39 @@
 module.exports = {
-  extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended'
-  ],
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    project: 'tsconfig.json',
-    sourceType: 'module'
-  },
-  plugins: ['@typescript-eslint'],
-  rules: {
-    '@typescript-eslint/naming-convention': [
-      'error',
-      {
-        selector: 'interface',
-        format: ['PascalCase'],
-        custom: {
-          regex: '^I[A-Z]',
-          match: true
-        }
-      }
-    ],
-    '@typescript-eslint/no-unused-vars': ['warn', { args: 'none' }],
-    '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-namespace': 'off',
-    '@typescript-eslint/no-use-before-define': 'off',
-    '@typescript-eslint/quotes': [
-      'error',
-      'single',
-      { avoidEscape: true, allowTemplateLiterals: false }
-    ],
-    curly: ['error', 'all'],
-    eqeqeq: 'error',
-    'prefer-arrow-callback': 'error'
-  }
+  // extends: [
+  //   'eslint:recommended',
+  //   'plugin:@typescript-eslint/eslint-recommended',
+  //   'plugin:@typescript-eslint/recommended',
+  //   'plugin:prettier/recommended'
+  // ],
+  // parser: '@typescript-eslint/parser',
+  // parserOptions: {
+  //   project: 'tsconfig.json',
+  //   sourceType: 'module'
+  // },
+  // plugins: ['@typescript-eslint'],
+  // rules: {
+  //   '@typescript-eslint/naming-convention': [
+  //     'error',
+  //     {
+  //       selector: 'interface',
+  //       format: ['PascalCase'],
+  //       custom: {
+  //         regex: '^I[A-Z]',
+  //         match: true
+  //       }
+  //     }
+  //   ],
+  //   '@typescript-eslint/no-unused-vars': ['warn', { args: 'none' }],
+  //   '@typescript-eslint/no-explicit-any': 'off',
+  //   '@typescript-eslint/no-namespace': 'off',
+  //   '@typescript-eslint/no-use-before-define': 'off',
+  //   '@typescript-eslint/quotes': [
+  //     'error',
+  //     'single',
+  //     { avoidEscape: true, allowTemplateLiterals: false }
+  //   ],
+  //   curly: ['error', 'all'],
+  //   eqeqeq: 'error',
+  //   'prefer-arrow-callback': 'error'
+  // }
 };

--- a/tests/data/myextension/.github/workflows/build.yml
+++ b/tests/data/myextension/.github/workflows/build.yml
@@ -1,0 +1,69 @@
+name: Build
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Install dependencies
+        run: python -m pip install -U jupyterlab~=3.1 check-manifest
+
+      - name: Build the extension
+        run: |
+          set -eux
+          jlpm
+          jlpm lint:check
+          python -m pip install .
+
+          jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
+          python -m jupyterlab.browser_check
+
+          check-manifest -v
+
+          pip install build
+          python -m build --sdist
+          cp dist/*.tar.gz myextension.tar.gz
+          pip uninstall -y "myextension" jupyterlab
+          rm -rf myextension
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: myextension-sdist
+          path: myextension.tar.gz
+
+  test_isolated:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+          architecture: 'x64'
+      - uses: actions/download-artifact@v2
+        with:
+          name: myextension-sdist
+      - name: Install and Test
+        run: |
+          set -eux
+          # Remove NodeJS, twice to take care of system and locally installed node versions.
+          sudo rm -rf $(which node)
+          sudo rm -rf $(which node)
+          pip install myextension.tar.gz
+          pip install jupyterlab
+          jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
+          python -m jupyterlab.browser_check --no-chrome-test

--- a/tests/data/myextension/.github/workflows/check-release.yml
+++ b/tests/data/myextension/.github/workflows/check-release.yml
@@ -1,0 +1,62 @@
+name: Check Release
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  check_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+          architecture: 'x64'
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+      - name: Cache pip
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Cache checked links
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pytest-link-check
+          key: ${{ runner.os }}-linkcheck-${{ hashFiles('**/.md') }}-md-links
+          restore-keys: |
+            ${{ runner.os }}-linkcheck-
+      - name: Upgrade packaging dependencies
+        run: |
+          pip install --upgrade pip setuptools wheel jupyter-packaging~=0.10 --user
+      - name: Install Dependencies
+        run: |
+          pip install .
+      - name: Check Release
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Distributions
+        uses: actions/upload-artifact@v2
+        with:
+          name: myextension-releaser-dist-${{ github.run_number }}
+          path: .jupyter_releaser_checkout/dist

--- a/tests/data/myextension/.gitignore
+++ b/tests/data/myextension/.gitignore
@@ -1,0 +1,114 @@
+*.bundle.*
+lib/
+node_modules/
+.eslintcache
+.stylelintcache
+*.egg-info/
+.ipynb_checkpoints
+*.tsbuildinfo
+myextension/labextension
+
+# Created by https://www.gitignore.io/api/python
+# Edit at https://www.gitignore.io/?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# End of https://www.gitignore.io/api/python
+
+# OSX files
+.DS_Store

--- a/tests/data/myextension/.prettierignore
+++ b/tests/data/myextension/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+**/node_modules
+**/lib
+**/package.json
+myextension

--- a/tests/data/myextension/.prettierrc
+++ b/tests/data/myextension/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none",
+  "arrowParens": "avoid",
+  "endOfLine": "auto"
+}

--- a/tests/data/myextension/.stylelintrc
+++ b/tests/data/myextension/.stylelintrc
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "stylelint-config-recommended",
+    "stylelint-config-standard",
+    "stylelint-prettier/recommended"
+  ],
+  "rules": {
+    "property-no-vendor-prefix": null,
+    "selector-no-vendor-prefix": null,
+    "value-no-vendor-prefix": null
+  }
+}

--- a/tests/data/myextension/CHANGELOG.md
+++ b/tests/data/myextension/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+<!-- <START NEW CHANGELOG ENTRY> -->
+
+<!-- <END NEW CHANGELOG ENTRY> -->

--- a/tests/data/myextension/LICENSE
+++ b/tests/data/myextension/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2022, me
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/data/myextension/MANIFEST.in
+++ b/tests/data/myextension/MANIFEST.in
@@ -1,0 +1,25 @@
+include LICENSE
+include *.md
+include pyproject.toml
+
+include package.json
+include install.json
+include ts*.json
+include yarn.lock
+
+graft myextension/labextension
+
+# Javascript files
+graft src
+graft style
+graft schema
+prune **/node_modules
+prune lib
+prune binder
+
+# Patterns to exclude from any directory
+global-exclude *~
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude .git
+global-exclude .ipynb_checkpoints

--- a/tests/data/myextension/README.md
+++ b/tests/data/myextension/README.md
@@ -1,0 +1,76 @@
+# myextension
+
+[![Github Actions Status](https://github.com/github_username/myextension/workflows/Build/badge.svg)](https://github.com/github_username/myextension/actions/workflows/build.yml)
+A JupyterLab extension.
+
+## Requirements
+
+- JupyterLab >= 3.0
+
+## Install
+
+To install the extension, execute:
+
+```bash
+pip install myextension
+```
+
+## Uninstall
+
+To remove the extension, execute:
+
+```bash
+pip uninstall myextension
+```
+
+## Contributing
+
+### Development install
+
+Note: You will need NodeJS to build the extension package.
+
+The `jlpm` command is JupyterLab's pinned version of
+[yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use
+`yarn` or `npm` in lieu of `jlpm` below.
+
+```bash
+# Clone the repo to your local environment
+# Change directory to the myextension directory
+# Install package in development mode
+pip install -e .
+# Link your development version of the extension with JupyterLab
+jupyter labextension develop . --overwrite
+# Rebuild extension Typescript source after making changes
+jlpm build
+```
+
+You can watch the source directory and run JupyterLab at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.
+
+```bash
+# Watch the source directory in one terminal, automatically rebuilding when needed
+jlpm watch
+# Run JupyterLab in another terminal
+jupyter lab
+```
+
+With the watch command running, every saved change will immediately be built locally and available in your running JupyterLab. Refresh JupyterLab to load the change in your browser (you may need to wait several seconds for the extension to be rebuilt).
+
+By default, the `jlpm build` command generates the source maps for this extension to make it easier to debug using the browser dev tools. To also generate source maps for the JupyterLab core extensions, you can run the following command:
+
+```bash
+jupyter lab build --minimize=False
+```
+
+### Development uninstall
+
+```bash
+pip uninstall myextension
+```
+
+In development mode, you will also need to remove the symlink created by `jupyter labextension develop`
+command. To find its location, you can run `jupyter labextension list` to figure out where the `labextensions`
+folder is located. Then you can remove the symlink named `myextension` within that folder.
+
+### Packaging the extension
+
+See [RELEASE](RELEASE.md)

--- a/tests/data/myextension/RELEASE.md
+++ b/tests/data/myextension/RELEASE.md
@@ -1,0 +1,61 @@
+# Making a new release of myextension
+
+The extension can be published to `PyPI` and `npm` manually or using the [Jupyter Releaser](https://github.com/jupyter-server/jupyter_releaser).
+
+## Manual release
+
+### Python package
+
+This extension can be distributed as Python
+packages. All of the Python
+packaging instructions in the `pyproject.toml` file to wrap your extension in a
+Python package. Before generating a package, we first need to install `build`.
+
+```bash
+pip install build twine
+```
+
+To create a Python source package (`.tar.gz`) and the binary package (`.whl`) in the `dist/` directory, do:
+
+```bash
+python -m build
+```
+
+> `python setup.py sdist bdist_wheel` is deprecated and will not work for this package.
+
+Then to upload the package to PyPI, do:
+
+```bash
+twine upload dist/*
+```
+
+### NPM package
+
+To publish the frontend part of the extension as a NPM package, do:
+
+```bash
+npm login
+npm publish --access public
+```
+
+## Automated releases with the Jupyter Releaser
+
+The extension repository should already be compatible with the Jupyter Releaser.
+
+Check out the [workflow documentation](https://github.com/jupyter-server/jupyter_releaser#typical-workflow) for more information.
+
+Here is a summary of the steps to cut a new release:
+
+- Fork the [`jupyter-releaser` repo](https://github.com/jupyter-server/jupyter_releaser)
+- Add `ADMIN_GITHUB_TOKEN`, `PYPI_TOKEN` and `NPM_TOKEN` to the Github Secrets in the fork
+- Go to the Actions panel
+- Run the "Draft Changelog" workflow
+- Merge the Changelog PR
+- Run the "Draft Release" workflow
+- Run the "Publish Release" workflow
+
+## Publishing to `conda-forge`
+
+If the package is not on conda forge yet, check the documentation to learn how to add it: https://conda-forge.org/docs/maintainer/adding_pkgs.html
+
+Otherwise a bot should pick up the new version publish to PyPI, and open a new PR on the feedstock repository automatically.

--- a/tests/data/myextension/install.json
+++ b/tests/data/myextension/install.json
@@ -1,0 +1,5 @@
+{
+  "packageManager": "python",
+  "packageName": "myextension",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package myextension"
+}

--- a/tests/data/myextension/myextension/__init__.py
+++ b/tests/data/myextension/myextension/__init__.py
@@ -1,0 +1,14 @@
+import json
+from pathlib import Path
+
+from ._version import __version__
+
+HERE = Path(__file__).parent.resolve()
+
+
+with (HERE / "labextension" / "package.json").open() as fid:
+    data = json.load(fid)
+
+
+def _jupyter_labextension_paths():
+    return [{"src": "labextension", "dest": data["name"]}]

--- a/tests/data/myextension/myextension/__init__.py
+++ b/tests/data/myextension/myextension/__init__.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from ._version import __version__
+from ._version import __version__  # noqa
 
 HERE = Path(__file__).parent.resolve()
 

--- a/tests/data/myextension/myextension/_version.py
+++ b/tests/data/myextension/myextension/_version.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+__all__ = ["__version__"]
+
+
+def _fetchVersion():
+    HERE = Path(__file__).parent.resolve()
+
+    for settings in HERE.rglob("package.json"):
+        try:
+            with settings.open() as f:
+                version = json.load(f)["version"]
+                return version.replace("-alpha.", "a").replace("-beta.", "b").replace("-rc.", "rc")
+        except FileNotFoundError:
+            pass
+
+    raise FileNotFoundError(f"Could not find package.json under dir {HERE!s}")
+
+
+__version__ = _fetchVersion()

--- a/tests/data/myextension/package.json
+++ b/tests/data/myextension/package.json
@@ -1,0 +1,101 @@
+{
+  "name": "myextension",
+  "version": "0.1.0",
+  "description": "A JupyterLab extension.",
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension"
+  ],
+  "homepage": "https://github.com/github_username/myextension",
+  "bugs": {
+    "url": "https://github.com/github_username/myextension/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": {
+    "name": "me",
+    "email": "me@me.com"
+  },
+  "files": [
+    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
+    "schema/*.json"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "style": "style/index.css",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/github_username/myextension.git"
+  },
+  "scripts": {
+    "build": "jlpm build:lib && jlpm build:labextension:dev",
+    "build:prod": "jlpm clean && jlpm build:lib && jlpm build:labextension",
+    "build:labextension": "jupyter labextension build .",
+    "build:labextension:dev": "jupyter labextension build --development True .",
+    "build:lib": "tsc",
+    "clean": "jlpm clean:lib",
+    "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
+    "clean:lintcache": "rimraf .eslintcache .stylelintcache",
+    "clean:labextension": "rimraf myextension/labextension",
+    "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
+    "eslint": "jlpm eslint:check --fix",
+    "eslint:check": "eslint . --cache --ext .ts,.tsx",
+    "install:extension": "jlpm build",
+    "lint": "jlpm stylelint && jlpm prettier && jlpm eslint",
+    "lint:check": "jlpm stylelint:check && jlpm prettier:check && jlpm eslint:check",
+    "prettier": "jlpm prettier:base --write --list-different",
+    "prettier:base": "prettier \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
+    "prettier:check": "jlpm prettier:base --check",
+    "stylelint": "jlpm stylelint:check --fix",
+    "stylelint:check": "stylelint --cache \"style/**/*.css\"",
+    "watch": "run-p watch:src watch:labextension",
+    "watch:src": "tsc -w",
+    "watch:labextension": "jupyter labextension watch ."
+  },
+  "dependencies": {
+    "@jupyterlab/application": "^3.1.0",
+    "@jupyterlab/settingregistry": "^3.1.0"
+  },
+  "devDependencies": {
+    "@jupyterlab/builder": "^3.1.0",
+    "@typescript-eslint/eslint-plugin": "^4.8.1",
+    "@typescript-eslint/parser": "^4.8.1",
+    "eslint": "^7.14.0",
+    "eslint-config-prettier": "^6.15.0",
+    "eslint-plugin-prettier": "^3.1.4",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^2.1.1",
+    "rimraf": "^3.0.2",
+    "stylelint": "^14.3.0",
+    "stylelint-config-prettier": "^9.0.3",
+    "stylelint-config-recommended": "^6.0.0",
+    "stylelint-config-standard": "~24.0.0",
+    "stylelint-prettier": "^2.0.0",
+    "typescript": "~4.1.3"
+  },
+  "sideEffects": [
+    "style/*.css",
+    "style/index.js"
+  ],
+  "styleModule": "style/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "jupyterlab": {
+    "extension": true,
+    "outputDir": "myextension/labextension",
+    "schemaDir": "schema"
+  },
+  "jupyter-releaser": {
+    "hooks": {
+      "before-build-npm": [
+        "python -m pip install jupyterlab~=3.1",
+        "jlpm"
+      ],
+      "before-build-python": [
+        "jlpm clean:all"
+      ]
+    }
+  }
+}

--- a/tests/data/myextension/pyproject.toml
+++ b/tests/data/myextension/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["jupyter_packaging~=0.10,<2", "jupyterlab~=3.1"]
+build-backend = "jupyter_packaging.build_api"
+
+[tool.jupyter-packaging.options]
+skip-if-exists = ["myextension/labextension/static/style.js"]
+ensured-targets = ["myextension/labextension/static/style.js", "myextension/labextension/package.json"]
+
+[tool.jupyter-packaging.builder]
+factory = "jupyter_packaging.npm_builder"
+
+[tool.jupyter-packaging.build-args]
+build_cmd = "build:prod"
+npm = ["jlpm"]
+
+[tool.check-manifest]
+ignore = ["myextension/labextension/**", "yarn.lock", ".*", "package-lock.json"]

--- a/tests/data/myextension/schema/plugin.json
+++ b/tests/data/myextension/schema/plugin.json
@@ -1,0 +1,8 @@
+{
+  "jupyter.lab.shortcuts": [],
+  "title": "myextension",
+  "description": "myextension settings.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/tests/data/myextension/setup.py
+++ b/tests/data/myextension/setup.py
@@ -1,0 +1,85 @@
+"""
+myextension setup
+"""
+import json
+import sys
+from pathlib import Path
+
+import setuptools
+
+HERE = Path(__file__).parent.resolve()
+
+# Get the package info from package.json
+pkg_json = json.loads((HERE / "package.json").read_bytes())
+
+# The name of the project
+name = "myextension"
+
+lab_path = HERE / pkg_json["jupyterlab"]["outputDir"]
+
+# Representative files that should exist after a successful build
+ensured_targets = [str(lab_path / "package.json"), str(lab_path / "static/style.js")]
+
+labext_name = pkg_json["name"]
+
+data_files_spec = [
+    ("share/jupyter/labextensions/%s" % labext_name, str(lab_path.relative_to(HERE)), "**"),
+    ("share/jupyter/labextensions/%s" % labext_name, ".", "install.json"),
+]
+
+long_description = (HERE / "README.md").read_text()
+
+version = pkg_json["version"].replace("-alpha.", "a").replace("-beta.", "b").replace("-rc.", "rc")
+
+setup_args = dict(
+    name=name,
+    version=version,
+    url=pkg_json["homepage"],
+    author=pkg_json["author"]["name"],
+    author_email=pkg_json["author"]["email"],
+    description=pkg_json["description"],
+    license=pkg_json["license"],
+    license_file="LICENSE",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    packages=setuptools.find_packages(),
+    install_requires=[],
+    zip_safe=False,
+    include_package_data=True,
+    python_requires=">=3.7",
+    platforms="Linux, Mac OS X, Windows",
+    keywords=["Jupyter", "JupyterLab", "JupyterLab3"],
+    classifiers=[
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Framework :: Jupyter",
+        "Framework :: Jupyter :: JupyterLab",
+        "Framework :: Jupyter :: JupyterLab :: 3",
+        "Framework :: Jupyter :: JupyterLab :: Extensions",
+        "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
+    ],
+)
+
+try:
+    from jupyter_packaging import get_data_files, npm_builder, wrap_installers
+
+    post_develop = npm_builder(build_cmd="install:extension", source_dir="src", build_dir=lab_path)
+    setup_args["cmdclass"] = wrap_installers(
+        post_develop=post_develop, ensured_targets=ensured_targets
+    )
+    setup_args["data_files"] = get_data_files(data_files_spec)
+except ImportError as e:
+    import logging
+
+    logging.basicConfig(format="%(levelname)s: %(message)s")
+    logging.warning("Build tool `jupyter-packaging` is missing. Install it with pip or conda.")
+    if not ("--name" in sys.argv or "--version" in sys.argv):
+        raise e
+
+if __name__ == "__main__":
+    setuptools.setup(**setup_args)

--- a/tests/data/myextension/src/index.ts
+++ b/tests/data/myextension/src/index.ts
@@ -1,0 +1,34 @@
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
+/**
+ * Initialization data for the myextension extension.
+ */
+const plugin: JupyterFrontEndPlugin<void> = {
+  id: 'myextension:plugin',
+  autoStart: true,
+  optional: [ISettingRegistry],
+  activate: (
+    app: JupyterFrontEnd,
+    settingRegistry: ISettingRegistry | null
+  ) => {
+    console.log('JupyterLab extension myextension is activated!');
+
+    if (settingRegistry) {
+      settingRegistry
+        .load(plugin.id)
+        .then(settings => {
+          console.log('myextension settings loaded:', settings.composite);
+        })
+        .catch(reason => {
+          console.error('Failed to load settings for myextension.', reason);
+        });
+    }
+  }
+};
+
+export default plugin;

--- a/tests/data/myextension/style/base.css
+++ b/tests/data/myextension/style/base.css
@@ -1,0 +1,5 @@
+/*
+    See the JupyterLab Developer Guide for useful CSS Patterns:
+
+    https://jupyterlab.readthedocs.io/en/stable/developer/css.html
+*/

--- a/tests/data/myextension/style/index.css
+++ b/tests/data/myextension/style/index.css
@@ -1,0 +1,1 @@
+@import url('base.css');

--- a/tests/data/myextension/style/index.js
+++ b/tests/data/myextension/style/index.js
@@ -1,0 +1,1 @@
+import './base.css';

--- a/tests/data/myextension/style/index.js
+++ b/tests/data/myextension/style/index.js
@@ -1,1 +1,1 @@
-import './base.css';
+//import './base.css';

--- a/tests/data/myextension/tsconfig.json
+++ b/tests/data/myextension/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "incremental": true,
+    "jsx": "react",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "preserveWatchOutput": true,
+    "resolveJsonModule": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "es2017",
+    "types": []
+  },
+  "include": ["src/*"]
+}

--- a/tests/data/pyproject.toml
+++ b/tests/data/pyproject.toml
@@ -1,0 +1,101 @@
+[build-system]
+requires = [
+    "hatchling>=1.3.1",
+]
+build-backend = "hatchling.build"
+
+[project]
+name = "myextension"
+description = "A JupyterLab extension."
+readme = "README.md"
+license = "BSD-3-Clause"
+requires-python = ">=3.7"
+authors = [
+    { name = "me", email = "me@me.com" },
+]
+keywords = [
+    "Jupyter",
+    "JupyterLab",
+    "JupyterLab3",
+]
+classifiers = [
+    "Framework :: Jupyter",
+    "Framework :: Jupyter :: JupyterLab",
+    "Framework :: Jupyter :: JupyterLab :: 3",
+    "Framework :: Jupyter :: JupyterLab :: Extensions",
+    "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+]
+dependencies = []
+version = "0.1.0"
+
+[project.urls]
+Homepage = "https://github.com/github_username/myextension"
+
+[tool.hatch.version]
+path = "myextension/__init__.py"
+
+[tool.hatch.build]
+artifacts = [
+    "myextension/labextension",
+]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"myextension/labextension/static" = "share/jupyter/labextensions/myextension/static"
+"install.json" = "share/jupyter/labextensions/myextension/install.json"
+"myextension/labextension/package.json" = "share/jupyter/labextensions/myextension/package.json"
+"myextension/labextension/schemas/myextension" = "share/jupyter/labextensions/myextension/schemas/myextension"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+    ".github",
+]
+
+[tool.hatch.build.hooks.jupyter-builder]
+dependencies = [
+    "hatch-jupyter-builder>=0.3.3",
+]
+build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = [
+    "myextension/labextension/static/style.js",
+    "myextension/labextension/package.json",
+]
+skip-if-exists = [
+    "myextension/labextension/static/style.js",
+]
+
+[tool.hatch.build.hooks.jupyter-builder.build-kwargs]
+build_cmd = "build:prod"
+npm = [
+    "jlpm",
+]
+
+[tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
+build_cmd = "install:extension"
+source_dir = "src"
+build_dir = "!!! needs manual input !!!"
+
+[tool.tbump]
+field = [
+    { name = "channel", default = "" },
+    { name = "release", default = "" },
+]
+file = [
+    { src = "pyproject.toml" },
+    { src = "myextension/_version.py" },
+    { src = "package.json" },
+]
+
+[tool.tbump.version]
+current = "0.1.0"
+regex = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<channel>a|b|rc|.dev)(?P<release>\\d+))?"
+
+[tool.tbump.git]
+message_template = "Bump to {new_version}"
+tag_template = "v{new_version}"

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,51 @@
+import glob
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import tomli
+
+HERE = Path(__file__).parent.absolute()
+
+
+@pytest.mark.migration_test
+def test_migration():
+    python = sys.executable
+    # Copy the source cookiecutter extension into two temporary directories.
+    with tempfile.TemporaryDirectory() as td1, tempfile.TemporaryDirectory() as td2:
+        source = HERE / "data"
+        shutil.copytree(source / "myextension", Path(td1) / "myextension")
+        shutil.copytree(source / "myextension", Path(td2) / "myextension")
+        target1 = Path(td1) / "myextension"
+        target2 = Path(td2) / "myextension"
+
+        # Migrate the first extension and compare its migrated pyproject.toml
+        # to the expected one.
+        subprocess.run([python, "-m", "hatch_jupyter_builder.migration", target1])
+        source_toml = source.joinpath("pyproject.toml").read_text(encoding="utf-8")
+        target_toml = target1.joinpath("pyproject.toml").read_text(encoding="utf-8")
+        source_data = tomli.loads(source_toml)
+        target_data = tomli.loads(target_toml)
+        assert source_data == target_data
+
+        # Compare the produced wheel and sdist for the migrated and unmigrated
+        # extensions.
+        for asset in ["sdist", "wheel"]:
+            subprocess.check_call(
+                [
+                    python,
+                    "-m",
+                    "hatch_jupyter_builder.migration.compare",
+                    str(target1),
+                    str(target2),
+                    asset,
+                ]
+            )
+
+            # Check the produced dist file in strict mode.
+            dist_files = glob.glob(str(target1 / "dist/*.*"))
+            assert len(dist_files) == 1
+            subprocess.check_call([python, "-m", "twine", "check", "--strict", dist_files[0]])

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -30,10 +30,10 @@ def test_migration():
         target_toml = target1.joinpath("pyproject.toml").read_text(encoding="utf-8")
         source_data = tomli.loads(source_toml)
         target_data = tomli.loads(target_toml)
-        for key, value in source_data.items():
+        for key, value in source_data["tool"]["hatch"].items():
             if isinstance(value, dict):
                 TestCase().assertDictEqual(value, target_data[key])
-        for key, value in target_data.items():
+        for key, value in target_data["tool"]["hatch"].items():
             if isinstance(value, dict):
                 TestCase().assertDictEqual(value, source_data[key])
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from unittest import TestCase
 
 import pytest
 import tomli
@@ -29,7 +30,7 @@ def test_migration():
         target_toml = target1.joinpath("pyproject.toml").read_text(encoding="utf-8")
         source_data = tomli.loads(source_toml)
         target_data = tomli.loads(target_toml)
-        assert source_data == target_data
+        TestCase().assertDictEqual(source_data, target_data)
 
         # Compare the produced wheel and sdist for the migrated and unmigrated
         # extensions.

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from unittest import TestCase
 
 import pytest
 import tomli

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -30,12 +30,7 @@ def test_migration():
         target_toml = target1.joinpath("pyproject.toml").read_text(encoding="utf-8")
         source_data = tomli.loads(source_toml)
         target_data = tomli.loads(target_toml)
-        for key, value in source_data["tool"]["hatch"].items():
-            if isinstance(value, dict):
-                TestCase().assertDictEqual(value, target_data["tool"]["hatch"][key])
-        for key, value in target_data["tool"]["hatch"].items():
-            if isinstance(value, dict):
-                TestCase().assertDictEqual(value, source_data["tool"]["hatch"][key])
+        assert source_data == target_data
 
         # Compare the produced wheel and sdist for the migrated and unmigrated
         # extensions.

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -30,7 +30,12 @@ def test_migration():
         target_toml = target1.joinpath("pyproject.toml").read_text(encoding="utf-8")
         source_data = tomli.loads(source_toml)
         target_data = tomli.loads(target_toml)
-        TestCase().assertDictEqual(source_data, target_data)
+        for key, value in source_data.items():
+            if isinstance(value, dict):
+                TestCase().assertDictEqual(value, target_data[key])
+        for key, value in target_data.items():
+            if isinstance(value, dict):
+                TestCase().assertDictEqual(value, source_data[key])
 
         # Compare the produced wheel and sdist for the migrated and unmigrated
         # extensions.

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -32,10 +32,10 @@ def test_migration():
         target_data = tomli.loads(target_toml)
         for key, value in source_data["tool"]["hatch"].items():
             if isinstance(value, dict):
-                TestCase().assertDictEqual(value, target_data[key])
+                TestCase().assertDictEqual(value, target_data["tool"]["hatch"][key])
         for key, value in target_data["tool"]["hatch"].items():
             if isinstance(value, dict):
-                TestCase().assertDictEqual(value, source_data[key])
+                TestCase().assertDictEqual(value, source_data["tool"]["hatch"][key])
 
         # Compare the produced wheel and sdist for the migrated and unmigrated
         # extensions.

--- a/tests/test_npm_builder.py
+++ b/tests/test_npm_builder.py
@@ -20,7 +20,10 @@ def test_npm_builder(mocker, repo):
     which.return_value = "foo"
     npm_builder("wheel", "standard", path=repo)
     run.assert_has_calls(
-        [call(["foo", "install"], cwd=str(repo)), call(["foo", "run", "build"], cwd=str(repo))]
+        [
+            call(["foo", "install"], cwd=str(repo), check=True),
+            call(["foo", "run", "build"], cwd=str(repo), check=True),
+        ]
     )
 
 
@@ -46,8 +49,8 @@ def test_npm_builder_yarn(mocker, repo):
     npm_builder("wheel", "standard", path=repo)
     run.assert_has_calls(
         [
-            call(["foo", "install"], cwd=str(repo)),
-            call(["foo", "run", "build"], cwd=str(repo)),
+            call(["foo", "install"], cwd=str(repo), check=True),
+            call(["foo", "run", "build"], cwd=str(repo), check=True),
         ]
     )
 
@@ -60,8 +63,8 @@ def test_npm_builder_missing_yarn(mocker, repo):
     npm_builder("wheel", "standard", path=repo)
     run.assert_has_calls(
         [
-            call(["foo", "install"], cwd=str(repo)),
-            call(["foo", "run", "build"], cwd=str(repo)),
+            call(["foo", "install"], cwd=str(repo), check=True),
+            call(["foo", "run", "build"], cwd=str(repo), check=True),
         ]
     )
 
@@ -73,8 +76,8 @@ def test_npm_builder_path(mocker, tmp_path):
     npm_builder("wheel", "standard", path=tmp_path)
     run.assert_has_calls(
         [
-            call(["foo", "install"], cwd=str(tmp_path)),
-            call(["foo", "run", "build"], cwd=str(tmp_path)),
+            call(["foo", "install"], cwd=str(tmp_path), check=True),
+            call(["foo", "run", "build"], cwd=str(tmp_path), check=True),
         ]
     )
 
@@ -86,8 +89,8 @@ def test_npm_builder_editable(mocker, repo):
     npm_builder("wheel", "editable", path=repo, editable_build_cmd="foo")
     run.assert_has_calls(
         [
-            call(["foo", "install"], cwd=str(repo)),
-            call(["foo", "run", "foo"], cwd=str(repo)),
+            call(["foo", "install"], cwd=str(repo), check=True),
+            call(["foo", "run", "foo"], cwd=str(repo), check=True),
         ]
     )
 
@@ -99,8 +102,8 @@ def test_npm_builder_npm_str(mocker, repo):
     npm_builder("wheel", "standard", path=repo, npm="npm")
     run.assert_has_calls(
         [
-            call(["npm", "install"], cwd=str(repo)),
-            call(["npm", "run", "build"], cwd=str(repo)),
+            call(["npm", "install"], cwd=str(repo), check=True),
+            call(["npm", "run", "build"], cwd=str(repo), check=True),
         ]
     )
 
@@ -110,7 +113,7 @@ def test_npm_builder_npm_build_command_none(mocker, repo):
     run = mocker.patch("hatch_jupyter_builder.utils.run")
     which.return_value = "npm"
     npm_builder("wheel", "standard", path=repo, build_cmd=None)
-    run.assert_has_calls([call(["npm", "install"], cwd=str(repo))])
+    run.assert_has_calls([call(["npm", "install"], cwd=str(repo), check=True)])
 
 
 def test_npm_builder_not_stale(mocker, repo):


### PR DESCRIPTION
Add scripts to migrate a Jupyter or Jupyter extension project from `setuptools` to `hatch`.
The script handles most of the migration automatically, but prints prompts for the user on recommended follow up actions.
There is also a comparison script to ensure that all assets remain the same in the produced dist files.
Adds a unit test that starts from a `setuptools`-based cookiecutter extension and verifies all aspects of migration.