### PR TITLE
Fix: convert _ to - in repo links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ classifiers = [
 dependencies = ["hatchling"]
 
 [project.urls]
-Documentation = "https://github.com/jupyterlab/hatch-jupyter-builder#readme"
-Issues = "https://github.com/jupyterlab/hatch-jupyter-builder/issues"
-Source = "https://github.com/jupyterlab/hatch-jupyter-builder"
+Documentation = "https://github.com/jupyterlab/hatch_jupyter_builder#readme"
+Issues = "https://github.com/jupyterlab/hatch_jupyter_builder/issues"
+Source = "https://github.com/jupyterlab/hatch_jupyter_builder"
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-mock", "pre-commit", "hatchling", "pytest-cov"]


### PR DESCRIPTION
@blink1073 apologies, the last PR was done by eye. I hadn't realised that the repo is actually under `hatch_jupyter_builder` not `hatch-jupyter-builder`