### PR TITLE
Migration script fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,6 @@ To compare dist files with a reference checkout, run the following:
 python -m hatch_jupyter_builder.compare_migration <source_dir> <target_dir> sdist
 ```
 
-The migration scripts can also be used without installation, using `pipx`, e.g.:
-
-```bash
-pipx hatch_jupyter_builder migrate .
-```
-
 Use `wheel` to compare wheel file contents.
 
 See the [documentation for more information on migration](https://hatch-jupyter-builder.readthedocs.io/en/latest/source/how_to_guides/index.html) for more details.

--- a/hatch_jupyter_builder/migrate/_migrate.py
+++ b/hatch_jupyter_builder/migrate/_migrate.py
@@ -79,6 +79,7 @@ os.environ["PYTHONPATH"] = prev_pythonpath
 # Move flake8 config to separate file, preserving comments.
 # Add .flake8 file to git.
 setup_cfg = Path("setup.cfg")
+flake8_path = Path(".flake8")
 flake8 = ["[flake8]"]
 if setup_cfg.exists():
     lines = setup_cfg.read_text("utf-8").splitlines()
@@ -97,8 +98,8 @@ if setup_cfg.exists():
         flake8.append(line)
 
     if matches:
-        Path(".flake8").write_text("\n".join(flake8) + "\n", "utf-8")
-        subprocess.run(["git", "add", ".flake"], check=False)
+        flake8_path.write_text("\n".join(flake8) + "\n", "utf-8")
+        subprocess.run(["git", "add", str(flake8_path)], check=False)
 
 
 # Migrate and remove unused config.


### PR DESCRIPTION
* removes the note about using `pipx` – the invocation is wrong, and finally, it doesn't work when corrected:
  ```
  $ pipx run hatch-jupyter-builder migrate .
  usage: /Users/akx/.local/pipx/.cache/c28885c1d0910f0/bin/python -m hatch_jupyter_builder.migrate [-h] target_dir
  /Users/akx/.local/pipx/.cache/c28885c1d0910f0/bin/python -m hatch_jupyter_builder.migrate: error: unrecognized arguments: .
  ```
* fixes a typo that causes Git to say `fatal: pathspec '.flake' did not match any files`