### PR TITLE
test_run: support spaces in sys.executable path

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,7 @@ def test_ensure_targets(tmp_path):
 
 
 def test_run():
-    cmd = f"{sys.executable} --version"
+    cmd = f"{shlex.quote(sys.executable)} --version"
     utils.run(cmd)
     utils.run(shlex.split(cmd))
 


### PR DESCRIPTION
On my Mac, hatch creates its virtual environments in `$HOME/Library/Application Support`.  So the python3 executable ends up at a path with a space in it.

The space in the path caused `test_run()` to fail, because without quotes the first `utis.run()` call would try and execute `$HOME/Library/Application` (up to the space) instead of the python3 executable.