### PR TITLE
Docs: fix `:ref:npm_builder_function` link

### DIFF
--- a/docs/source/get_started/config.md
+++ b/docs/source/get_started/config.md
@@ -80,5 +80,5 @@ The optional `install-pre-commit-hook` boolean causes a `pre-commit` hook to be 
 
 ## Npm Builder Function
 
-This library provides a convenenice `npm_builder` function which can be
-used to build `npm` assets as part of the build. See the :ref:`npm_builder_function` for more information on usage.
+This library provides a convenience {py:obj}`npm_builder <hatch_jupyter_builder.utils.npm_builder>`
+function which can be used to build `npm` assets as part of the build.


### PR DESCRIPTION
The `npm_builder_function` link on https://hatch-jupyter-builder.readthedocs.io/en/latest/source/get_started/config.html is currently not a link:
<img width="1290" height="266" alt="image" src="https://github.com/user-attachments/assets/9e78c18b-5467-47bc-a18c-06ce89bb19c2" />
